### PR TITLE
Fix TL-B storage scheme comments in jetton minter and wallet

### DIFF
--- a/contracts/jetton-minter.fc
+++ b/contracts/jetton-minter.fc
@@ -9,7 +9,7 @@
 #include "gas.fc";
 
 global int merkle_root;
-;; storage#_ total_supply:Coins admin_address:MsgAddress next_admin_address:MsgAddress jetton_wallet_code:^Cell metadata_uri:^Cell = Storage;
+;; storage#_ total_supply:Coins admin_address:MsgAddress next_admin_address:MsgAddress jetton_wallet_code:^Cell metadata_uri:^Cell merkle_root:uint256 = Storage;
 (int, slice, slice, cell, cell) load_data() impure inline {
     slice ds = get_data().begin_parse();
     var data = (

--- a/contracts/jetton-wallet.fc
+++ b/contracts/jetton-wallet.fc
@@ -18,7 +18,7 @@
   storage#_ status:uint4
             balance:Coins owner_address:MsgAddressInt
             jetton_master_address:MsgAddressInt
-            merkle_root:uint256 = Storage;
+            merkle_root:uint256 salt:(## 10) = Storage;
 -}
 
 global int merkle_root;

--- a/scripts/checkWalletLib.ts
+++ b/scripts/checkWalletLib.ts
@@ -14,14 +14,14 @@ export async function run(provider: NetworkProvider) {
     const walletCode = (await minter.getJettonData()).walletCode;
 
     if(walletLib.equals(walletCode)) {
-        console.log("Minter wallet code is library and matches the current source")
+        console.log("Minter wallet code is a library and matches the current source")
         return 0;
     }
 
     const isLibrary = walletCode.isExotic && walletCode.bits.length == 256 + 8 && walletCode.bits.substring(0, 8).toString() == '02';
 
     if(isLibrary) {
-        console.log("Minter wallet code is not a library but doesn't match expected code cell");
+        console.log("Minter wallet code is a library but doesn't match expected code cell");
         console.log("Expected code hash:", expHash);
         console.log("Got:", walletCode.bits.substring(8, walletCode.bits.length - 8).toString().toLowerCase());
     } else {


### PR DESCRIPTION
This PR fixes TL-B storage scheme comments in the jetton minter and jetton wallet contracts by adding missing fields to the documented storage layout. It updates the minter comment to include “merkle_root:uint256” and the wallet comment to include “salt:(## 10)”. These are documentation-only changes and do not affect contract behavior.